### PR TITLE
Docker user mapping

### DIFF
--- a/lib/functions
+++ b/lib/functions
@@ -90,8 +90,10 @@ terraform(){
     return $?
   fi
 
-
   local IMAGE="${TERRAFORM_DOCKER_IMAGE:-hashicorp/terraform}:${TERRAFORM_VERSION:-latest}"
+
+  # Define user mapping on Linux. Does not work on Mac
+  test "$(uname -s)" = "Linux" && DOCKER_ENV="${DOCKER_ENV} -u ${UID}:root"
 
   # Setup volume mounts for config and context
   test "$(pwd)" != '/' &&  VOLUMES="-v $(pwd):$(pwd)"


### PR DESCRIPTION
Hi guys,

This is a PR to solve an annoying issue we have in the CI when we are running Terraform in Docker through Gaia.

When we run Terraform in Docker we have to mount volumes in the Docker container to have access within the container to the Terraform definitions. The user inside the container is `root` (using the default `hashicorp/terraform` image), but on our CI server the user is different. So the volumes are mounted with the `root` user and can't be deleted by CI user then. 

To solve this issue we have to define a [user mapping](https://medium.com/@mccode/understanding-how-uid-and-gid-work-in-docker-containers-c37a01d01cf).
Unfortunately the user mapping only works when the architecture is Linux (I don't know on Windows). On mac it does not works because the Docker setup is not native.

Nik