### PR TITLE
Workspace selecion fix

### DIFF
--- a/bin/gaia
+++ b/bin/gaia
@@ -135,7 +135,7 @@ init(){
 
   test -n "${workspace}" || workspace="default"
   local exists
-  exists=$(terraform workspace list | grep "${workspace}" > /dev/null 2>&1; echo $?)
+  exists=$(terraform workspace list | grep -E "(^|\s+)${workspace}$" > /dev/null 2>&1; echo $?)
   if [ "${exists}" = "0" ]; then
     info "Selecting workspace '${workspace}'..."
     run_command="terraform workspace select ${workspace}"


### PR DESCRIPTION
Hi guys,

In this PR we modify gaia to fix workspace selection between prod and prod-pp environments.

In [this](https://buildkite.com/bandsintown/widget-api/builds/53#797792db-b48d-4654-a6e6-b9d2037786d3) build we could see the error:

`
Workspace "prod" doesn't exist.

  | You can create this workspace with the "new" subcommand.


`
Brat
