### PR TITLE
[IT-26] Pass -auto-approve to terraform apply

### DIFF
--- a/bin/gaia
+++ b/bin/gaia
@@ -160,7 +160,7 @@ plan(){
 apply(){
   if [  "xtrue" != "x${dry_run}" ]; then
     info "Applying module '${module_path}'..."
-    run_command="terraform apply ${vars} ${cmd_opts}"
+    run_command="terraform apply -auto-approve=true ${vars} ${cmd_opts}"
     test "xtrue" = "x${verbose}" && debug "${run_command} "
     test "xtrue" = "x${show_commands}" || eval "${run_command}"
   fi


### PR DESCRIPTION
Terraform 0.11 made it mandatory for `terraform apply` to run on a plan file, or to pass the `-auto-approve` flag. This is backwards compatible with Terraform 0.10.